### PR TITLE
Revert Spy Disguise Speed back to always 2 seconds

### DIFF
--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -6674,10 +6674,10 @@ void CTFPlayerShared::Disguise( int nTeam, int nClass, CTFPlayer* pDesiredTarget
 
 	// STAGING_SPY
 	// Quick disguise if you already disguised
-	if ( InCond( TF_COND_DISGUISED ) )
-	{
-		flTimeToDisguise = TF_TIME_TO_QUICK_DISGUISE;
-	}
+//	if ( InCond( TF_COND_DISGUISED ) )
+//	{
+//		flTimeToDisguise = TF_TIME_TO_QUICK_DISGUISE;
+//	}
 
 	if ( pDesiredTarget )
 	{


### PR DESCRIPTION
Comment out quick disguise logic for disguised players.

!!!UNTESTED!!!
I am just guessing from a memory patch used in the SourceMod weapon reverts plugin

<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Reverts disguise speed back to the old Spy change disguise duration (Pre-Gun Mettle) (Oct 9, 2007 - Jul 2, 2015) (0.5 sec back to 2 secs)