### PR TITLE
Revert Nerf to Wrangler Shield Repair and Refill

### DIFF
--- a/src/game/server/tf/tf_obj_sentrygun.cpp
+++ b/src/game/server/tf/tf_obj_sentrygun.cpp
@@ -585,10 +585,10 @@ bool CObjectSentrygun::OnWrenchHit( CTFPlayer *pPlayer, CTFWrench *pWrench, Vect
 		// STAGING_ENGY
 		// Mod repair value by shield value
 		float flRepairAmount = pWrench->GetRepairAmount();
-		if ( m_nShieldLevel == SHIELD_NORMAL )
-		{
-			flRepairAmount *= SHIELD_NORMAL_VALUE;
-		}
+		// if ( m_nShieldLevel == SHIELD_NORMAL )
+		// {
+			// flRepairAmount *= SHIELD_NORMAL_VALUE;
+		// }
 		
 		if ( Command_Repair( pPlayer, flRepairAmount, 1.f ) )
 		{
@@ -627,10 +627,10 @@ bool CObjectSentrygun::OnWrenchHit( CTFPlayer *pPlayer, CTFWrench *pWrench, Vect
 
 			// STAGING_ENGY
 			// Mod Ammo if shielded
-			if ( m_nShieldLevel == SHIELD_NORMAL )
-			{
-				iAmountToAdd *= SHIELD_NORMAL_VALUE;
-			}
+			// if ( m_nShieldLevel == SHIELD_NORMAL )
+			// {
+				// iAmountToAdd *= SHIELD_NORMAL_VALUE;
+			// }
 
 			pPlayer->RemoveAmmo( iAmountToAdd * tf_sentrygun_metal_per_shell.GetInt(), TF_AMMO_METAL );
 			m_iAmmoShells += iAmountToAdd;
@@ -653,10 +653,10 @@ bool CObjectSentrygun::OnWrenchHit( CTFPlayer *pPlayer, CTFWrench *pWrench, Vect
 
 			// STAGING_ENGY
 			// Mod Ammo if shielded
-			if ( m_nShieldLevel == SHIELD_NORMAL )
-			{
-				iAmountToAdd *= SHIELD_NORMAL_VALUE;
-			}
+			// if ( m_nShieldLevel == SHIELD_NORMAL )
+			// {
+				// iAmountToAdd *= SHIELD_NORMAL_VALUE;
+			// }
 
 			pPlayer->RemoveAmmo( iAmountToAdd * tf_sentrygun_metal_per_rocket.GetFloat(), TF_AMMO_METAL );
 			m_iAmmoRockets += iAmountToAdd;


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Fully repair and refill while shield is up
Based from VerdiusArcana's sourcemod memory patches

[July 2, 2015 Patch 1](https://wiki.teamfortress.com/wiki/July_2,_2015_Patch) ([Gun Mettle Update](https://wiki.teamfortress.com/wiki/Gun_Mettle_Update))
    Changed attributes:
        Ammo and Repair given to a shielded Sentry is reduced by the strength of the shield (66% reduced) when shield is active.