### PR TITLE
Reverted Engineer Mechanics

### DIFF
--- a/src/game/server/tf/tf_obj.cpp
+++ b/src/game/server/tf/tf_obj.cpp
@@ -2123,7 +2123,7 @@ float CBaseObject::GetConstructionMultiplier( void )
 			// STAGING_ENGY
 			// each Player adds a fixed amount of speed boost
 			// Carry deploy hits add more
-			flMultiplier += ( m_ConstructorList[iThis].flValue );
+			flMultiplier *= ( m_ConstructorList[iThis].flValue );
 		}
 	}
 

--- a/src/game/server/tf/tf_obj.cpp
+++ b/src/game/server/tf/tf_obj.cpp
@@ -2849,7 +2849,7 @@ bool CBaseObject::CanBeUpgraded( CTFPlayer *pPlayer )
 //-----------------------------------------------------------------------------
 // Purpose: Separated so it can be triggered by wrench hit or by vgui screen
 //-----------------------------------------------------------------------------
-int CBaseObject::Command_Repair( CTFPlayer *pActivator, float flAmount, float flRepairMod, float flRepairToMetalRatio /*= 3.f*/, bool bSendEvent /*= false*/ )
+int CBaseObject::Command_Repair( CTFPlayer *pActivator, float flAmount, float flRepairMod, float flRepairToMetalRatio /*= 5.f*/, bool bSendEvent /*= false*/ )
 {
 	if ( !CanBeRepaired() )
 		return false;

--- a/src/game/server/tf/tf_obj.h
+++ b/src/game/server/tf/tf_obj.h
@@ -184,7 +184,7 @@ public:
 	virtual bool	InputWrenchHit( CTFPlayer *pPlayer, CTFWrench *pWrench, Vector hitLoc );
 	virtual bool	OnWrenchHit( CTFPlayer *pPlayer, CTFWrench *pWrench, Vector hitLoc );
 	virtual bool	CheckUpgradeOnHit( CTFPlayer *pPlayer );
-	virtual int		Command_Repair( CTFPlayer *pActivator, float flAmount, float flRepairMod, float flRepairToMetalRatio = 3.f, bool bSendEvent = true );
+	virtual int		Command_Repair( CTFPlayer *pActivator, float flAmount, float flRepairMod, float flRepairToMetalRatio = 5.f, bool bSendEvent = true );
 	virtual void	DoWrenchHitEffect( Vector hitLoc, bool bRepairHit, bool bUpgradeHit );
 
 	virtual bool	ShouldBeMiniBuilding( CTFPlayer* pPlayer );

--- a/src/game/server/tf/tf_obj_teleporter.cpp
+++ b/src/game/server/tf/tf_obj_teleporter.cpp
@@ -630,7 +630,7 @@ void CObjectTeleporter::TeleporterTouch( CBaseEntity *pOther )
 //-----------------------------------------------------------------------------
 // Purpose:
 //-----------------------------------------------------------------------------
-int CObjectTeleporter::Command_Repair( CTFPlayer *pActivator, float flAmount, float flRepairMod, float flRepairToMetalRatio /*= 3.f*/, bool bSendEvent /*= false*/ )
+int CObjectTeleporter::Command_Repair( CTFPlayer *pActivator, float flAmount, float flRepairMod, float flRepairToMetalRatio /*= 5.f*/, bool bSendEvent /*= false*/ )
 {
 	// Teleporter-specific: 5 health costs 1 metal
 	flRepairToMetalRatio = 5.f;

--- a/src/game/server/tf/tf_obj_teleporter.h
+++ b/src/game/server/tf/tf_obj_teleporter.h
@@ -81,7 +81,7 @@ public:
 	}
 
 	// Wrench hits
-	virtual int		Command_Repair( CTFPlayer *pActivator, float flAmount, float flRepairMod, float flRepairToMetalRatio = 3.f, bool bSendEvent = true ) OVERRIDE;
+	virtual int		Command_Repair( CTFPlayer *pActivator, float flAmount, float flRepairMod, float flRepairToMetalRatio = 5.f, bool bSendEvent = true ) OVERRIDE;
 	void			AddHealth( int nHealthToAdd )
 	{
 		SetHealth( MIN( GetMaxHealth(), GetHealth() + nHealthToAdd ) );

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -5629,7 +5629,7 @@ bool CTFGameRules::ApplyOnDamageModifyRules( CTakeDamageInfo &info, CBaseEntity 
 			CObjectSentrygun *pSentry = dynamic_cast<CObjectSentrygun*>( info.GetInflictor() );
 			if ( pSentry )
 			{
-				vAttackerPos = pSentry->WorldSpaceCenter();
+				// vAttackerPos = pSentry->WorldSpaceCenter(); // this line makes damage falloff depend on sentry position; not the player
 				// Sentries have a much further optimal distance
 				flOptimalDistance = SENTRY_MAX_RANGE;
 			}

--- a/src/game/shared/tf/tf_weapon_wrench.cpp
+++ b/src/game/shared/tf/tf_weapon_wrench.cpp
@@ -225,16 +225,14 @@ void CTFWrench::Equip( CBaseCombatCharacter *pOwner )
 	CTFPlayer *pPlayer = ToTFPlayer( pOwner );
 	if ( pPlayer )
 	{
-		// if switching too gunslinger, blow up other sentry
-		int iMiniSentry = 0;
-		CALL_ATTRIB_HOOK_INT( iMiniSentry, wrench_builds_minisentry );
-		if ( iMiniSentry )
+		// detonate all buildings on wrench change
+		for ( int i = 0; i < pPlayer->GetObjectCount(); ++i )
 		{
-			// Just detonate Sentries
-			CObjectSentrygun *pSentry = dynamic_cast<CObjectSentrygun*>( pPlayer->GetObjectOfType( OBJ_SENTRYGUN ) );
-			if ( pSentry )
+			CBaseObject *pObject = pPlayer->GetObject( i );
+
+			if ( pObject )
 			{
-				pSentry->DetonateObject();
+				pObject->DetonateObject();
 			}
 		}
 	}
@@ -250,16 +248,14 @@ void CTFWrench::Detach( void )
 	CTFPlayer *pPlayer = GetTFPlayerOwner();
 	if ( pPlayer )
 	{
-		// if switching off of gunslinger detonate
-		int iMiniSentry = 0;
-		CALL_ATTRIB_HOOK_INT( iMiniSentry, wrench_builds_minisentry );
-		if ( iMiniSentry )
+		// detonate all buildings on wrench change
+		for ( int i = 0; i < pPlayer->GetObjectCount(); ++i )
 		{
-			// Just detonate Sentries
-			CObjectSentrygun *pSentry = dynamic_cast<CObjectSentrygun*>( pPlayer->GetObjectOfType( OBJ_SENTRYGUN ) );
-			if ( pSentry )
+			CBaseObject *pObject = pPlayer->GetObject( i );
+
+			if ( pObject )
 			{
-				pSentry->DetonateObject();
+				pObject->DetonateObject();
 			}
 		}
 	}

--- a/src/game/shared/tf/tf_weapon_wrench.cpp
+++ b/src/game/shared/tf/tf_weapon_wrench.cpp
@@ -290,7 +290,7 @@ void CTFWrench::ApplyBuildingHealthUpgrade( void )
 #endif
 
 // STAGING_ENGY
-ConVar tf_construction_build_rate_multiplier( "tf_construction_build_rate_multiplier", "1.5f", FCVAR_REPLICATED | FCVAR_DEVELOPMENTONLY );
+ConVar tf_construction_build_rate_multiplier( "tf_construction_build_rate_multiplier", "2.0f", FCVAR_REPLICATED | FCVAR_DEVELOPMENTONLY );
 float CTFWrench::GetConstructionValue( void )
 {
 	float flValue = tf_construction_build_rate_multiplier.GetFloat();


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Contains the following reverts:
1. Reverted construction speed and boost from additive back to multiplicative 
2. Reverted Wrench equip change - reverted back to whenever Engineer changes to ANY wrench, all his buildings are automatically destroyed regardless.
3. Reverted Building Repair Costs - from 3HP per metal back to 5HP per metal
4. Reverted Sentry Gun bullet damage falloff mechanics - bullet damage falloff reverted back to depend on the player's position, not the Sentry Gun's.

# How to Test
- [x] 1. Test construction speed boost by measuring with a stopwatch.
    - [x] The amount of time needed to construct a dispenser with this revert while being construction boosted (always being hit by wrench) should be **around 11.01 s**
    - [x] The amount of time needed to construct a dispenser with this revert while NOT being construction boosted (not being hit by a wrench like an f2p player) should be **around 21.18 s**
    - [July 2, 2015 Patch](https://wiki.teamfortress.com/wiki/July_2,_2015_Patch)
- [x] 2. Test Wrench equip change. Build all of your buildings to completion, then change Wrenches via resupply cabinet and killbind on loadout change.
    - [July 2, 2015 Patch](https://wiki.teamfortress.com/wiki/July_2,_2015_Patch)
- [x] 3. Test Building Repair Costs. Build a Lvl 3. Sentry Gun, let another enemy player damage it below 100HP, then repair it. Do not fire it or anything, use the Wrangler to prevent that. For every Wrench hit, you should spend 20 metal to repair 100 building HP.
   - [July 2, 2015 Patch](https://wiki.teamfortress.com/wiki/July_2,_2015_Patch)
   - "Building repair costs increased from 20 metal to 33 metal to repair 100hp per wrench hit (from 5HP per metal to 3HP per metal)" 
- [x] 4. Test Sentry Gun bullet damage falloff. Using the Wrangler makes this easier. Enable damage numbers, go near an enemy, shoot them with the sentry, then go far from the enemy, the shoot them again. There should be lower damage when you go farther away from the enemy and vice versa.
   -  [June 18, 2014 Patch](https://wiki.teamfortress.com/wiki/June_18,_2014_Patch) ([Love & War Update](https://wiki.teamfortress.com/wiki/Love_%26_War_Update))
   - Sentry bullets are now affected by damage falloff outside of sentry scan range.
   - Sentry bullet damage has been changed so it calculates damage based on the Sentry Gun's position, not the Engineer's.