### PR TITLE
Huntsman Reverts

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -15316,7 +15316,7 @@ void CTFPlayer::DoTauntAttack( void )
 		if ( iTauntAttack == TAUNTATK_SNIPER_ARROW_STAB_IMPALE )
 		{
 			m_iTauntAttack = TAUNTATK_SNIPER_ARROW_STAB_KILL;
-			m_flTauntAttackTime = gpGlobals->curtime + 1.30;
+			m_flTauntAttackTime = gpGlobals->curtime + 0.05;
 		}
 		else if ( iTauntAttack == TAUNTATK_ENGINEER_ARM_IMPALE )
 		{

--- a/src/game/shared/tf/tf_weapon_compound_bow.cpp
+++ b/src/game/shared/tf/tf_weapon_compound_bow.cpp
@@ -190,6 +190,10 @@ void CTFCompoundBow::PrimaryAttack( void )
 	if ( m_flNextPrimaryAttack > gpGlobals->curtime )
 		return;
 
+	// Check if user is currently mid-air and has drawn an arrow. If true, do not fire an arrow until the user touches the ground.
+	if (!(GetFlags() & FL_ONGROUND) && m_Shared.InCond( TF_COND_AIMING ) )
+		return;
+
 	if ( m_bNoFire )
 		return;
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
- [ ] 1. Restore Stab Stab Stab Taunt Attack Loop Bug
- [ ] 2. Revert Huntsman not being able to fire when drawn and while in mid-air. When already drawn mid-air, only fires when the Sniper touches the ground.