### PR TITLE
Fix All Buildings not Detonating Correctly when Engineer Switches to Any Wrench

### DIFF
--- a/src/game/server/tf/tf_obj.cpp
+++ b/src/game/server/tf/tf_obj.cpp
@@ -2131,7 +2131,7 @@ float CBaseObject::GetConstructionMultiplier( void )
 	CTFPlayer* pBuilder = GetOwner();
 	if( pBuilder )
 	{
-		flMultiplier *= pBuilder->GetObjectBuildSpeedMultiplier( ObjectType(), m_bCarryDeploy );
+		flMultiplier += pBuilder->GetObjectBuildSpeedMultiplier( ObjectType(), m_bCarryDeploy );
 	}
 
 	return flMultiplier;

--- a/src/game/server/tf/tf_obj.cpp
+++ b/src/game/server/tf/tf_obj.cpp
@@ -2131,7 +2131,7 @@ float CBaseObject::GetConstructionMultiplier( void )
 	CTFPlayer* pBuilder = GetOwner();
 	if( pBuilder )
 	{
-		flMultiplier += pBuilder->GetObjectBuildSpeedMultiplier( ObjectType(), m_bCarryDeploy );
+		flMultiplier *= pBuilder->GetObjectBuildSpeedMultiplier( ObjectType(), m_bCarryDeploy );
 	}
 
 	return flMultiplier;

--- a/src/game/shared/tf/tf_weapon_wrench.cpp
+++ b/src/game/shared/tf/tf_weapon_wrench.cpp
@@ -226,13 +226,12 @@ void CTFWrench::Equip( CBaseCombatCharacter *pOwner )
 	if ( pPlayer )
 	{
 		// detonate all buildings on wrench change
-		for ( int i = 0; i < pPlayer->GetObjectCount(); ++i )
+		for ( int i = pPlayer->GetObjectCount()-1; i >= 0; i-- )
 		{
-			CBaseObject *pObject = pPlayer->GetObject( i );
-
-			if ( pObject )
+			CBaseObject *pObj = pPlayer->GetObject(i);
+			if ( pObj )
 			{
-				pObject->DetonateObject();
+				pObj->DetonateObject();
 			}
 		}
 	}
@@ -249,13 +248,12 @@ void CTFWrench::Detach( void )
 	if ( pPlayer )
 	{
 		// detonate all buildings on wrench change
-		for ( int i = 0; i < pPlayer->GetObjectCount(); ++i )
+		for ( int i = pPlayer->GetObjectCount()-1; i >= 0; i-- )
 		{
-			CBaseObject *pObject = pPlayer->GetObject( i );
-
-			if ( pObject )
+			CBaseObject *pObj = pPlayer->GetObject(i);
+			if ( pObj )
 			{
-				pObject->DetonateObject();
+				pObj->DetonateObject();
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This PR fixes a case where Engineer has 4 buildings present, and whenever he switches to any Wrench, 1 building is not detonated. This is likely due to how the game identifies the buildings of a player.