### PR TITLE
MainMenu PubRelease: 7.7.7

### DIFF
--- a/game/tf2pc/cfg/valve.rc
+++ b/game/tf2pc/cfg/valve.rc
@@ -19,3 +19,5 @@ stuffcmds
 sv_unlockedchapters 99
 
 sv_voicecodec vaudio_speex
+
+net_disconnect_reason 1

--- a/game/tf2pc/gameinfo.txt
+++ b/game/tf2pc/gameinfo.txt
@@ -1,7 +1,7 @@
 "GameInfo"
 {
 	game					"Team Fortress 2: Pre-Conomy"
-	title					"mainmenuoverride Test Build v. 776/2000 (Public Release) June 1, 2026 19:05:43"
+	title					"mainmenuoverride Test Build v. 777/2000 (Public Release) June 6, 2026 09:57:57"
 	type 					multiplayer_only
 	icon					"resource/icon"
 	nomodels				1

--- a/game/tf2pc/resource/ui/classloadoutpanel.res
+++ b/game/tf2pc/resource/ui/classloadoutpanel.res
@@ -340,7 +340,7 @@
 		"tall"			"25"
 		"autoResize"	"0"
 		"pinCorner"		"0"
-		"visible"		"1"
+		"visible"		"0"
 		"enabled"		"0"
 		"tabPosition"	"0"
 		"labelText"		"#X_DeleteItem"

--- a/game/tf2pc/resource/ui/classselection.res
+++ b/game/tf2pc/resource/ui/classselection.res
@@ -1622,6 +1622,23 @@
 		"paintbackgroundenabled" "1"
 		"bgcolor_override" "255 255 255 0"
 		
+		//class light fix
+		"lights"
+        {
+            "spotlight"
+            {
+                "name"                    "spot"
+                "color"                 "0.85 0.85 0.85"
+                "attenuation"            "0.9"
+                "origin"                "0 0 200"
+                "direction"                "320 10 0"
+                "inner_cone_angle"        "5"
+                "outer_cone_angle"        "200"
+                "maxDistance"            "0"
+                "exponent"                "5"
+            }
+        }
+		
 		"model"
 		{
 			"force_pos"	"1"

--- a/game/tf2pc/resource/ui/scoreboard.res
+++ b/game/tf2pc/resource/ui/scoreboard.res
@@ -609,7 +609,7 @@
 		"ypos"			"417"	[$WIN32]
 		"ypos"			"350"	[$X360]
 		"zpos"			"3"
-		"wide"			"145"	[$WIN32]
+		"wide"			"147"	[$WIN32]
 		"wide"			"130"	[$X360]
 		"tall"			"20"
 		"autoResize"	"0"

--- a/game/tf2pc/resource/ui/winpanel.res
+++ b/game/tf2pc/resource/ui/winpanel.res
@@ -100,10 +100,10 @@
 			"visible"		"1"
 			"enabled"		"1"
 		}							
-		"RedTeamLabel"
+		"RedTeaamLabel"
 		{
 			"ControlName"		"CExLabel"
-			"fieldName"		"RedTeamLabel"
+			"fieldName"		"RedTeaamLabel"
 			"font"			"ScoreboardTeamName"
 			"labelText"		"%redteamname%"
 			"textAlignment"		"east"

--- a/src/game/client/econ/item_selection_panel.cpp
+++ b/src/game/client/econ/item_selection_panel.cpp
@@ -182,6 +182,11 @@ void CItemSelectionPanel::ApplySchemeSettings(vgui::IScheme* pScheme)
 
 	//m_pSlotLabel = dynamic_cast<vgui::Label*>(FindChildByName("ItemSlotLabel"));
 
+	for (int i = 0; i < m_pItemModelPanels.Count(); i++)
+	{
+		m_pItemModelPanels[i]->SetParent(m_pItemContainer);
+	}
+
 	if (m_pItemContainerScroller)
 	{
 		m_pItemContainerScroller->GetScrollbar()->SetAutohideButtons(true);
@@ -314,6 +319,13 @@ void CItemSelectionPanel::PerformLayout(void)
 {
 	BaseClass::PerformLayout();
 
+#ifdef DEBUG
+	Msg("PerformLayout: m_nItemX=%d m_nItemYDelta=%d m_nButtonXPos=%d iItemTall=%d containerWide=%d\n",
+		m_nItemX, m_nItemYDelta, m_nButtonXPos,
+		m_pItemModelPanels.Count() > 0 ? m_pItemModelPanels[0]->GetTall() : -1,
+		m_pItemContainer->GetWide());
+#endif
+
 	if (m_pItemModelPanels.Count() == 0)
 		return;
 
@@ -348,6 +360,10 @@ void CItemSelectionPanel::PerformLayout(void)
 	{
 		if (!m_pItemModelPanels[i])
 			continue;
+
+		m_pItemModelPanels[i]->SetPos(m_nItemX, y);
+		m_pItemModelPanels[i]->SetVisible(true);
+		m_pItemModelPanels[i]->SetZPos(2);
 
 		// Only show panels that actually have content
 		bool bVisible = m_pItemModelPanels[i]->HasItem() ||
@@ -406,13 +422,13 @@ void CItemSelectionPanel::PerformLayout(void)
 
 		y += m_pItemModelPanels[i]->GetTall() + m_nItemYDelta;
 
-		//m_pItemModelPanels[i]->SetPos(m_nItemX, y);
-		// why are we doing this ??!?!?!
-		m_pItemModelPanels[i]->SetPos(m_nItemX+235, y-95);
-
+#ifdef DEBUG
 		int x, y, w, t;
 		m_pItemModelPanels[i]->GetBounds(x, y, w, t);
+
 		Msg(" ItemModelPanels[%i]: pos=(%i,%i) size=(%i,%i) visible=%i\n", i, x, y, w, t, m_pItemModelPanels[i]->IsVisible());
+#endif // DEBUG
+
 	}
 
 	for (int i = m_pItemModelPanels.Count(); i < m_vecChangeButtons.Count(); i++)
@@ -674,7 +690,9 @@ void CItemSelectionPanel::NotifySelectionReturned(CItemModelPanel* pItemPanel)
 //-----------------------------------------------------------------------------
 void CItemSelectionPanel::UpdateModelPanels(void)
 {
+#ifdef DEBUG
 	Msg("ItemSelectionPanel::UpdateModelPanels, yay!\n");
+#endif
 	// If we're showing the whole backpack, go through the inventory like the backpack does.
 	if (m_bShowingEntireBackpack)
 	{
@@ -1197,7 +1215,9 @@ equip_region_mask_t GenerateEquipRegionConflictMask(int iClass, int iUpToSlot, i
 //-----------------------------------------------------------------------------
 void CEquipSlotItemSelectionPanel::UpdateModelPanelsForSelection(void)
 {
+#ifdef DEBUG
 	Msg("CEquipSlotItemSelectionPanel::UpdateModelPanelsForSelection, yay!\n");
+#endif
 
 	Assert(!DisplayOnlyAllowUniqueQualityCheckbox());
 
@@ -1328,6 +1348,12 @@ void CEquipSlotItemSelectionPanel::UpdateModelPanelsForSelection(void)
 			//m_pItemModelPanels[i]->SetForceShowEquipped(bShowEquipped);
 			m_pItemModelPanels[i]->SetForceShowEquipped(false);
 			m_pItemModelPanels[i]->SetItem(vecDisplayItems[iItemIndex].m_pEconItemView);
+			int	m_iItemWide;
+			int	m_iItemTall;
+			m_iItemWide = 270;
+			m_iItemTall = 80;
+
+			m_pItemModelPanels[i]->SetSize(m_iItemWide, m_iItemTall);
 			//m_pItemModelPanels[i]->SetGreyedOut(pszGreyOutReason);
 		}
 		else

--- a/src/game/client/tf/tf_hud_mainmenuoverride.cpp
+++ b/src/game/client/tf/tf_hud_mainmenuoverride.cpp
@@ -1257,7 +1257,9 @@ void CHudMainMenuOverride::PerformLayout( void )
 	this->m_pLeftDataPanel = dynamic_cast<vgui::EditablePanel*>(FindChildByName("TopLeftDataPanel"));
 	this->m_pRightDataPanel = dynamic_cast<vgui::EditablePanel*>(FindChildByName("TopRightDataPanel"));
 
+#ifdef DEBUG
 	Msg("CHudMainMenuOverride::PerformLayout: m_pLeftDataPanel=%p, m_pRightDataPanel=%p\n", m_pLeftDataPanel, m_pRightDataPanel);
+#endif
 
 	if (m_pLeftDataPanel && m_pRightDataPanel)
 	{
@@ -2204,6 +2206,10 @@ void CHudMainMenuOverride::OnCommand( const char *command )
 		{
 			UpdateNotifications();
 		}
+	}
+	else if (!Q_stricmp(command, "offlinepractice"))
+	{
+		GetClientModeTFNormal()->GameUI()->SendMainMenuCommand("engine training_showdlg");
 	}
 	else if ( !Q_stricmp( command, "armory_open" ) )
 	{

--- a/src/game/client/tf/tf_hud_mainmenuoverride.h
+++ b/src/game/client/tf/tf_hud_mainmenuoverride.h
@@ -50,6 +50,7 @@ enum mm_button_styles
 	MMBS_CUSTOM,
 };
 
+
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
@@ -63,11 +64,12 @@ class CHudMainMenuOverride : public vgui::EditablePanel, public IViewPortPanel, 
 		MMHA_PRACTICE,
 		MMHA_NEWUSERFORUM,
 		MMHA_OPTIONS,
-		MMHA_LOADOUT,
-		MMHA_STORE,
+		//MMHA_LOADOUT,
+		//MMHA_STORE,
 
 		NUM_ANIMS
 	};
+
 
 public:
 	CHudMainMenuOverride( IViewPort *pViewPort );
@@ -123,6 +125,9 @@ public:
 	ELanguage	 GetLastMOTDRequestLanguage( void ) { return m_nLastMOTDRequestLanguage; }
 
 	void		 UpdatePromotionalCodes( void );
+
+	void		 CheckTrainingStatus(void);
+	CExplanationPopup* StartHighlightAnimation(mm_highlight_anims iAnim);
 
 	MESSAGE_FUNC( OnUpdateMenu, "UpdateMenu" );
 	MESSAGE_FUNC_PARAMS( OnConfirm, "ConfirmDlgResult", data );

--- a/src/game/client/tf/vgui/charinfo_loadout_subpanel.cpp
+++ b/src/game/client/tf/vgui/charinfo_loadout_subpanel.cpp
@@ -422,7 +422,34 @@ void CCharInfoLoadoutSubPanel::OnSelectionStarted( void )
 //-----------------------------------------------------------------------------
 void CCharInfoLoadoutSubPanel::OnSelectionEnded( void )
 {
+	/*m_iCurrentClassIndex = TF_CLASS_UNDEFINED;
+
+	m_pClassLoadoutPanel->SetClass(TF_CLASS_UNDEFINED);
+	m_pClassLoadoutPanel->ShowPanel(TF_CLASS_UNDEFINED, false, false);
+
+	m_bSnapClassLayout = false;
+	m_bClassLayoutDirty = true;
+	InvalidateLayout();
+
+	RequestFocus();
+	*/
 	PostActionSignal( new KeyValues("SelectionUpdate", "open", 0 ) );
+}
+
+void CCharInfoLoadoutSubPanel::OnLoadoutBackPressed(void)
+{
+	m_iCurrentClassIndex = TF_CLASS_UNDEFINED;
+
+	m_pClassLoadoutPanel->SetClass(TF_CLASS_UNDEFINED);
+	m_pClassLoadoutPanel->ShowPanel(TF_CLASS_UNDEFINED, false, false);
+
+	m_bSnapClassLayout = false;
+	m_bClassLayoutDirty = true;
+	InvalidateLayout();
+
+	RequestFocus();
+
+	PostActionSignal(new KeyValues("SelectionUpdate", "open", 0));
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/client/tf/vgui/charinfo_loadout_subpanel.h
+++ b/src/game/client/tf/vgui/charinfo_loadout_subpanel.h
@@ -125,6 +125,7 @@ public:
 	MESSAGE_FUNC( OnCraftingClosed, "CraftingClosed" );
 	MESSAGE_FUNC( OnArmoryClosed, "ArmoryClosed" );
 	MESSAGE_FUNC( OnCharInfoClosing, "CharInfoClosing" );
+	MESSAGE_FUNC( OnLoadoutBackPressed, "LoadoutBackPressed" );
 
 private:
 	void		RequestInventoryRefresh();

--- a/src/game/client/tf/vgui/class_loadout_panel.cpp
+++ b/src/game/client/tf/vgui/class_loadout_panel.cpp
@@ -1184,7 +1184,9 @@ void CClassLoadoutPanel::SetLoadoutPage(classloadoutpage_t loadoutPage)
 //-----------------------------------------------------------------------------
 void CClassLoadoutPanel::OnLoadoutClosed(void)
 {
+#ifdef DEBUG
 	Msg("CClassLoadoutPanel::OnLoadoutClosed\n");
+#endif
 	m_iCurrentClassIndex = TF_CLASS_UNDEFINED;
 	ClearItemOptionsMenu();
 	UpdateModelPanels();
@@ -1211,9 +1213,10 @@ void CClassLoadoutPanel::OnLoadoutClosed(void)
 //-----------------------------------------------------------------------------
 void CClassLoadoutPanel::OnCommand(const char* command)
 {
+#ifdef DEBUG
 	//check our sanity once again
 	Msg("CClassLoadoutPanel::OnCommand: %s\n", command);
-
+#endif
 	if (FStrEq(command, "characterloadout"))
 	{
 		SetLoadoutPage(CHARACTER_LOADOUT_PAGE);
@@ -1300,19 +1303,11 @@ void CClassLoadoutPanel::OnCommand(const char* command)
 			return;
 		}
 	}
-	//backout from the class_loadout_panel
+	// Full Backing out from loadout panel
 	else if (!V_strnicmp(command, "back", 4))
 	{
-		//fixme todo: deadlock fix
-		if (m_pSelectionPanel)
-		{
-			m_pSelectionPanel->SetVisible(false);
-			m_pSelectionPanel->MarkForDeletion();
-			m_pSelectionPanel = NULL;
-		}
-
-		ClearItemOptionsMenu();
-		ShowPanel(false, false);
+		PostMessage(GetParent(), new KeyValues("LoadoutBackPressed"));
+		OnLoadoutClosed();
 		return;
 	}
 

--- a/src/game/client/tf/vgui/tf_classmenu.cpp
+++ b/src/game/client/tf/vgui/tf_classmenu.cpp
@@ -776,12 +776,12 @@ void CTFClassMenu::SelectClass( int iClass )
 
 	m_pClassTipsPanel->SetClass( iClass );
 
-	enginesound->StopSoundByGuid( m_nBaseMusicGuid );
-	CBroadcastRecipientFilter filter;
-	char nClassMusicStr[64];
-	sprintf( nClassMusicStr, "music.class_menu_0%i", iClass );
-	CBaseEntity::EmitSound( filter, SOUND_FROM_UI_PANEL, nClassMusicStr );
-	m_nBaseMusicGuid = enginesound->GetGuidForLastSoundEmitted();
+	//enginesound->StopSoundByGuid( m_nBaseMusicGuid );
+	//CBroadcastRecipientFilter filter;
+	//char nClassMusicStr[64];
+	//sprintf( nClassMusicStr, "music.class_menu_0%i", iClass );
+	//CBaseEntity::EmitSound( filter, SOUND_FROM_UI_PANEL, nClassMusicStr );
+	//m_nBaseMusicGuid = enginesound->GetGuidForLastSoundEmitted();
 	
 
 }

--- a/src/game/shared/voice_gamemgr.cpp
+++ b/src/game/shared/voice_gamemgr.cpp
@@ -37,7 +37,7 @@ ConVar voice_serverdebug( "voice_serverdebug", "0" );
 
 // Set game rules to allow all clients to talk to each other.
 // Muted players still can't talk to each other.
-ConVar sv_alltalk( "sv_alltalk", "1", FCVAR_NOTIFY | FCVAR_REPLICATED, "Players can hear all other players, no team restrictions" );
+ConVar sv_alltalk( "sv_alltalk", "0", FCVAR_NOTIFY | FCVAR_REPLICATED, "Players can hear all other players, no team restrictions" );
 
 
 CVoiceGameMgr g_VoiceGameMgr;


### PR DESCRIPTION
7.7.7 Release is now public.

new:
* Players now send a disconnect message by default.

bugfixes:
* Finalized item_selection_panel.
* Backing out from the loadout panel no longer causes a deadlock state.
* Moved the Delete Button to the appropriate backpack panel.
* Debug messages now only appear if you compile a DEBUG build.
* Long map names now fit the Scoreboard (example: Thunder Mountain)
* Fixed lighting for each class on the selection panel.

to-dos:
* Players need to click on the item's name to equip that item. The next release will address this; the buttons currently are placeholders and don't work.
* Add in Training Mode and Offline Practice.