### PR TITLE
Bullet Impact and ObjectiveTimer Fix

### DIFF
--- a/game/tf2pc/resource/ui/hudobjectivetimepanel.res
+++ b/game/tf2pc/resource/ui/hudobjectivetimepanel.res
@@ -64,7 +64,7 @@
 		"ypos_hidef"	"15"
 		"ypos_lodef"	"18"
 		"zpos"			"3"
-		"wide"			"45"
+		"wide"			"47"
 		"wide_minmode"	"30"
 		"wide_lodef"	"50"
 		"tall"			"31"

--- a/src/game/client/fx_impact.cpp
+++ b/src/game/client/fx_impact.cpp
@@ -208,7 +208,7 @@ char const *GetImpactDecal( C_BaseEntity *pEntity, int iMaterial, int iDamageTyp
 //-----------------------------------------------------------------------------
 // Purpose: Perform custom effects based on the Decal index
 //-----------------------------------------------------------------------------
-static ConVar cl_new_impact_effects( "cl_new_impact_effects", "1" );
+static ConVar cl_new_impact_effects( "cl_new_impact_effects", "0" );
 
 struct ImpactEffect_t
 {


### PR DESCRIPTION
The change reverts the old system for bullet impact, which fixes visible issues with water and snow effects. Also, the timer has been widened so that at ~22-24 minutes, it no longer gets visibly cut off.
